### PR TITLE
New/updated tests

### DIFF
--- a/src/RepoIntegrityTests/.editorconfig
+++ b/src/RepoIntegrityTests/.editorconfig
@@ -1,0 +1,4 @@
+[*.cs]
+
+# Justification: Test project
+dotnet_diagnostic.CA2007.severity = none

--- a/src/RepoIntegrityTests/.editorconfig
+++ b/src/RepoIntegrityTests/.editorconfig
@@ -2,3 +2,5 @@
 
 # Justification: Test project
 dotnet_diagnostic.CA2007.severity = none
+dotnet_diagnostic.PS0013.severity = none
+dotnet_diagnostic.PS0018.severity = none

--- a/src/RepoIntegrityTests/Infrastructure/NuGetData.cs
+++ b/src/RepoIntegrityTests/Infrastructure/NuGetData.cs
@@ -1,0 +1,29 @@
+namespace RepoIntegrityTests.Infrastructure;
+
+using NuGet.Configuration;
+using NuGet.Protocol.Core.Types;
+
+public static class NuGetData
+{
+    static readonly Dictionary<string, IPackageSearchMetadata> packageInfo = [];
+    static readonly PackageMetadataResource packageMetadata;
+    static readonly SourceCacheContext cache = new();
+
+    static NuGetData()
+    {
+        var nugetRepo = new SourceRepository(new PackageSource("https://api.nuget.org/v3/index.json"), NuGet.Protocol.Core.Types.Repository.Provider.GetCoreV3());
+        packageMetadata = nugetRepo.GetResource<PackageMetadataResource>();
+    }
+
+    public static async Task<IPackageSearchMetadata> GetPackageInfo(string packageId)
+    {
+        if (!packageInfo.TryGetValue(packageId, out var info))
+        {
+            var allVersions = await packageMetadata.GetMetadataAsync(packageId, false, false, cache, NuGet.Common.NullLogger.Instance, default);
+            var latest = allVersions.OrderByDescending(p => p.Identity.Version).FirstOrDefault();
+            packageInfo[packageId] = info = latest;
+        }
+
+        return info;
+    }
+}

--- a/src/RepoIntegrityTests/Infrastructure/NuGetData.cs
+++ b/src/RepoIntegrityTests/Infrastructure/NuGetData.cs
@@ -19,7 +19,7 @@ public static class NuGetData
     {
         if (!packageInfo.TryGetValue(packageId, out var info))
         {
-            var allVersions = await packageMetadata.GetMetadataAsync(packageId, false, false, cache, NuGet.Common.NullLogger.Instance, default);
+            var allVersions = await packageMetadata.GetMetadataAsync(packageId, false, false, cache, NuGet.Common.NullLogger.Instance, CancellationToken.None);
             var latest = allVersions.OrderByDescending(p => p.Identity.Version).FirstOrDefault();
             packageInfo[packageId] = info = latest;
         }

--- a/src/RepoIntegrityTests/Infrastructure/TestRunner.cs
+++ b/src/RepoIntegrityTests/Infrastructure/TestRunner.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices;
@@ -67,8 +68,19 @@
 
         public void Run(Action<FileContext> testAction)
         {
-            var results = files.ForEach(testAction)
-                .Where(f => f.IsFailed)
+            _ = files.ForEach(testAction);
+            ProcessResults();
+        }
+
+        public async Task RunAsync(Func<FileContext, Task> testAction)
+        {
+            await Task.WhenAll(files.Select(testAction));
+            ProcessResults();
+        }
+
+        void ProcessResults()
+        {
+            var results = files.Where(f => f.IsFailed)
                 .SelectMany(f =>
                 {
                     if (!f.FailReasons.Any())

--- a/src/RepoIntegrityTests/PackageReferences.cs
+++ b/src/RepoIntegrityTests/PackageReferences.cs
@@ -199,6 +199,7 @@
         public void KnownPackagesArePrivateAssetsAll()
         {
             new TestRunner("*.csproj", "Package references for known build tools should be marked with PrivateAssets=\"All\"")
+                .ProjectsProducingNuGetPackages()
                 .Run(f =>
                 {
                     var packageRefs = f.XDocument.XPathSelectElements("/Project/ItemGroup/PackageReference");

--- a/src/RepoIntegrityTests/PackageReferences.cs
+++ b/src/RepoIntegrityTests/PackageReferences.cs
@@ -103,7 +103,7 @@
                     {
                         var name = pkgRef.Attribute("Include").Value;
                         var versionStr = pkgRef.Attribute("Version")?.Value;
-                        var privateAssets = pkgRef.Attribute("PrivateAssets")?.Value is not null;
+                        var disableAutoVersionRange = string.Equals(pkgRef.Attribute("AutomaticVersionRange")?.Value, "false", StringComparison.OrdinalIgnoreCase);
 
                         if (versionStr is null)
                         {
@@ -112,40 +112,21 @@
                         }
 
                         var isSingleVersion = NuGetVersion.TryParse(versionStr, out var version);
-                        var isRange = VersionRange.TryParse(versionStr, out var range);
-
-                        if (privateAssets)
+                        if (!isSingleVersion)
                         {
-                            if (!isSingleVersion)
-                            {
-                                f.Fail($"Dependency '{name}' with PrivateAssets should use a single version so that Dependabot can update it.");
-                            }
-                        }
-                        else if (PackageDoesNotRequireVersionRanges(name, out var trustedPrefix))
-                        {
-                            if (!isSingleVersion)
-                            {
-                                f.Fail($"Dependency '{name}' should use a single version because the prefix '{trustedPrefix}' is trusted to not introduce breaking changes.");
-                            }
-                        }
-                        else
-                        {
-                            if (!isRange || !range.HasLowerAndUpperBounds)
-                            {
-                                bool isSingleVersionPrerelease = isSingleVersion && version.IsPrerelease;
-                                if (!isSingleVersionPrerelease)
-                                {
-                                    f.Fail($"Dependency '{name}' should be defined as a version range so that users can't accidentally update to a version with breaking changes.");
-                                }
-                            }
+                            f.Fail($"Dependency '{name}' should use a single version number because tooling is now used to generate version ranges at compile time.");
+                            continue;
                         }
 
-                        // Only on a release workflow for an RTM release
-                        if (isRtmRelease)
+                        if (PackageShouldNotGenerateVersionRange(name, out var trustedPrefix) && !disableAutoVersionRange)
                         {
-                            var minVersionPrerelease = range.MinVersion?.IsPrerelease ?? false;
-                            var maxVersionPrerelease = range.MaxVersion?.IsPrerelease ?? false;
-                            if (minVersionPrerelease || maxVersionPrerelease)
+                            f.Fail($"Dependency '{name}' should include AutomaticVersionRange=\"false\" because the prefix '{trustedPrefix}' is trusted to not introduce breaking changes.");
+                        }
+
+                        // Eventually, when these tests are run in release workflows, remove `|| true` to only break when attempting a release
+                        if (isRtmRelease || true)
+                        {
+                            if (version.IsPrerelease)
                             {
                                 f.Fail($"Dependency '{name}' cannot use a prerelease package on an RTM release.");
                             }
@@ -155,11 +136,11 @@
         }
 
         [Test]
-        public void DependenciesDefinedAsRangesMustBeSpecifiedInTests()
+        public void ComponentDependenciesShouldNotBeDuplicatedInTests()
         {
             List<(string projectFileName, string rangedDependency)> publicDeps = [];
 
-            new TestRunner("*.csproj", "Find public dependencies that are version-ranged")
+            new TestRunner("*.csproj", "Find public dependencies")
                 .ProjectsProducingNuGetPackages()
                 .Run(f =>
                 {
@@ -169,8 +150,10 @@
                     {
                         var name = pkgRef.Attribute("Include").Value;
                         var versionStr = pkgRef.Attribute("Version")?.Value;
+                        var isSingleVersion = NuGetVersion.TryParse(versionStr, out var version);
+                        var privateAssets = pkgRef.Attribute("PrivateAssets")?.Value is not null;
 
-                        if (VersionRange.TryParse(versionStr, out var range) && range.HasLowerAndUpperBounds)
+                        if (isSingleVersion && !privateAssets)
                         {
                             var projectFileName = Path.GetFileName(f.FullPath);
                             publicDeps.Add((projectFileName, name));
@@ -197,14 +180,14 @@
                         var parts = relativePath.Split('\\');
                         var projectFileName = parts.Last();
 
-                        var rangedDeps = lookup[projectFileName] ?? [];
+                        var publicDeps = lookup[projectFileName] ?? [];
 
-                        foreach (var depName in rangedDeps)
+                        foreach (var depName in publicDeps)
                         {
                             var findPackageRef = f.XDocument.XPathSelectElement($"/Project/ItemGroup/PackageReference[@Include='{depName}']");
-                            if (findPackageRef is null || !NuGetVersion.TryParse(findPackageRef.Attribute("Version")?.Value, out _))
+                            if (findPackageRef is not null)
                             {
-                                f.Fail($"Test project '{f.FileName}' has a project reference to '{projectFileName}' but does not specify an explicit version for the ranged dependency '{depName}'.");
+                                f.Fail($"Test project '{f.FileName}' has a project reference to '{projectFileName}' and should not repeat the PackageReference for '{depName}'.");
                             }
                         }
                     }
@@ -301,7 +284,7 @@
                 });
         }
 
-        static bool PackageDoesNotRequireVersionRanges(string name, out string trustedPrefix)
+        static bool PackageShouldNotGenerateVersionRange(string name, out string trustedPrefix)
         {
             foreach (var prefix in packagePrefixesNotRequiringVersionRanges)
             {

--- a/src/RepoIntegrityTests/RepoIntegrityTests.csproj
+++ b/src/RepoIntegrityTests/RepoIntegrityTests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>true</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,6 +11,7 @@
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit.Analyzers" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.11.1" />
     <PackageReference Include="NuGet.Versioning" Version="6.12.1" />
     <PackageReference Include="YamlDotNet" Version="16.1.3" />
   </ItemGroup>


### PR DESCRIPTION
* No more PackageReference version ranges
* Fail on deprecated NuGet packages
* Fixes to workflow tests based on running against ServiceControl's new container workflows