### PR TITLE
Create ci.yml so this repo has a check for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  deploy:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4.3.1
+        with:
+          dotnet-version: 9.0.x
+      - name: Build
+        run: dotnet build src --configuration Release


### PR DESCRIPTION
This is part of https://github.com/Particular/PlatformInternals/issues/900
We need a check on PRs so when Renovate tries to update the project it won't succeed without building first.