### PR TITLE
Update test project validation

### DIFF
--- a/src/RepoIntegrityTests/Infrastructure/FileContextExtensions.cs
+++ b/src/RepoIntegrityTests/Infrastructure/FileContextExtensions.cs
@@ -10,6 +10,9 @@ public static class FileContextExtensions
     public static bool IsTestProject(this FileContext file) =>
         file.XDocument.XPathSelectElements("/Project/ItemGroup/PackageReference[@Include='Microsoft.NET.Test.Sdk']").Any();
 
+    public static bool IsAnalyzerTestProject(this FileContext file) =>
+        file.IsTestProject() && file.XDocument.XPathSelectElements("/Project/ItemGroup/PackageReference[@Include='Microsoft.CodeAnalysis.CSharp.Workspaces']").Any();
+
     public static bool ProducesLibraryNuGetPackage(this FileContext file)
     {
         var doc = file.XDocument;

--- a/src/RepoIntegrityTests/Infrastructure/TestRunner.cs
+++ b/src/RepoIntegrityTests/Infrastructure/TestRunner.cs
@@ -49,9 +49,15 @@ public class TestRunner
         return this;
     }
 
-    public TestRunner TestProjects()
+    public TestRunner TestProjects(bool includeAnalyzerTestProjects = true)
     {
         files = files.Where(f => f.IsTestProject());
+
+        if (!includeAnalyzerTestProjects)
+        {
+            files = files.Where(f => !f.IsAnalyzerTestProject());
+        }
+
         return this;
     }
 

--- a/src/RepoIntegrityTests/TestProjects.cs
+++ b/src/RepoIntegrityTests/TestProjects.cs
@@ -1,6 +1,5 @@
 ﻿namespace RepoIntegrityTests;
 
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.XPath;
 using NUnit.Framework;
@@ -57,8 +56,6 @@ public partial class TestProjects
         // Empty if nothing in workflow file, could mean all tests are net4xx
         var expectedFrameworks = explicitNetVersionsRequested.FirstOrDefault()?.Select(DotNetVersionToTargetFramework).ToArray() ?? [];
 
-        var collectedTestFrameworks = new List<(string path, string frameworks)>();
-
         Console.WriteLine("Expected expectedFrameworks: " + string.Join(", ", expectedFrameworks));
 
         new TestRunner("*.csproj", "Find tests")
@@ -75,43 +72,28 @@ public partial class TestProjects
 
                 var nonNetFxFrameworks = frameworks.Where(f => !f.StartsWith("net4")).ToArray();
 
-                collectedTestFrameworks.Add((file.FullPath, string.Join(';', nonNetFxFrameworks)));
-
                 if (expectedFrameworks is null && frameworks.All(tfm => tfm.StartsWith("net4")))
                 {
                     // net4xx TFM doesn't need a dotnet-setup
                     return;
                 }
 
-                var nonNetfxFrameworks = frameworks.Where(tfm => !tfm.StartsWith("net4")).ToArray();
-
-                if (!nonNetfxFrameworks.All(tfm => expectedFrameworks.Contains(tfm)))
+                foreach (var framework in nonNetFxFrameworks)
                 {
-                    file.Fail("Target frameworks don't match the dotnet-versions in the ci.yml workflow");
+                    if (!expectedFrameworks.Contains(framework))
+                    {
+                        file.Fail($"Target frameworks include a framework that is not in the dotnet-versions in the ci.yml workflow: {framework}");
+                    }
+                }
+
+                foreach (var framework in expectedFrameworks)
+                {
+                    if (!nonNetFxFrameworks.Contains(framework))
+                    {
+                        file.Fail($"Target frameworks are missing a framework that is in the dotnet-versions in the ci.yml workflow: {framework}");
+                    }
                 }
             });
-
-        var groups = collectedTestFrameworks
-            .Where(x => !string.IsNullOrEmpty(x.frameworks))
-            .GroupBy(x => x.frameworks)
-            .OrderBy(g => g.Count())
-            .ToArray();
-
-        if (groups.Length > 1)
-        {
-            var msg = new StringBuilder().AppendLine("The target frameworks of the test projects do not all match:");
-
-            foreach (var g in groups)
-            {
-                msg.AppendLine($"  * Target Frameworks: '{g.Key}':");
-                foreach (var proj in g)
-                {
-                    msg.AppendLine($"    * {proj.path}");
-                }
-            }
-
-            Assert.Fail(msg.ToString());
-        }
     }
 
     string DotNetVersionToTargetFramework(string dotnetVersion)

--- a/src/RepoIntegrityTests/TestProjects.cs
+++ b/src/RepoIntegrityTests/TestProjects.cs
@@ -60,7 +60,7 @@ public partial class TestProjects
 
         new TestRunner("*.csproj", "Find tests")
             .SdkProjects()
-            .TestProjects()
+            .TestProjects(includeAnalyzerTestProjects: false)
             .Run(file =>
             {
                 var frameworksText = file.XDocument.XPathSelectElement("/Project/PropertyGroup/TargetFramework")?.Value


### PR DESCRIPTION
This PR makes the following changes to test project validation:

- Test projects are now compared directly to the .NET versions in the CI workflow, and ensures that they target all of the versions listed there. This ensures that test projects are multi-targeted when multiple .NET versions are in the workflow.
  - This change also has the effect of making the exclusion rules work for the `ValidateProjectFrameworks` test,
- Analyzer test projects have special rules, so there is now a way to exclude these projects from being selected by `TestProjects`.
  - The `ValidateProjectFrameworks` has been updated to exclude analyzer test projects.


A separate set of tests should be added to enforce the specific rules around analyzer test projects, but I'm leaving that for now as work to be done in a follow-up PR.

