### PR TITLE
Change CPM test from Warn to Fail

### DIFF
--- a/src/RepoIntegrityTests/PackageReferences.cs
+++ b/src/RepoIntegrityTests/PackageReferences.cs
@@ -520,7 +520,7 @@ public partial class PackageReferences
         new TestRunner("Directory.Packages.props", "Repos should not use Central Package Management.", failIfNoMatches: false)
             .Run(f =>
             {
-                f.Warn("Central Package Management file found.");
+                f.Fail("Central Package Management file found.");
             });
     }
 


### PR DESCRIPTION
Now that all the exceptions are in place, we can change the CPM test from Warn to Fail.