### PR TITLE
Limit the wildcard remove check to items that reference source packages

### DIFF
--- a/src/RepoIntegrityTests/GeneratePathProperty.cs
+++ b/src/RepoIntegrityTests/GeneratePathProperty.cs
@@ -32,7 +32,7 @@ public class GeneratePathProperty
                         ItemGroup = el.Parent,
                         RemoveValue = el.Attribute("Remove")?.Value
                     })
-                    .Where(x => x.RemoveValue.Contains("**"))
+                    .Where(x => x.RemoveValue.StartsWith("$(Pkg") && x.RemoveValue.Contains("**"))
                     .ToArray();
 
                 foreach (var remove in removesWithWildcard)


### PR DESCRIPTION
ServiceControl uses shared tests that are defined in local folders rather than nuget packages, and in some cases subsets of tests need to be excluded.

This check was picking up those local folder exclusions that do not require a conditional inclusion.