### PR TITLE
Find steps in parallel blocks so that tests that rely on visibility of certain steps will not fail

### DIFF
--- a/src/RepoIntegrityTests/Infrastructure/ActionsWorkflow.cs
+++ b/src/RepoIntegrityTests/Infrastructure/ActionsWorkflow.cs
@@ -37,6 +37,10 @@ public class ActionsWorkflow
         {
             var job = JsonSerializer.Deserialize<WorkflowJob>(pair.Value, options);
             job.Id = pair.Key;
+            // job.Steps deserializes awkwardly where a "parallel" step would be a node with null values,
+            // so we specifically parse out top-level steps and then a comprehensive list of steps
+            job.Steps = ParseTopLevelSteps(pair.Value["steps"], options);
+            job.AllSteps = ParseAllSteps(pair.Value["steps"], options);
 
             if (pair.Value["defaults"] is not null)
             {
@@ -122,6 +126,52 @@ public class ActionsWorkflow
 
         throw new Exception("Unable to parse workflow triggers");
     }
+
+    static JobStep[] ParseTopLevelSteps(JsonNode stepsNode, JsonSerializerOptions options)
+    {
+        if (stepsNode is not JsonArray stepsArray)
+        {
+            return [];
+        }
+
+        return stepsArray
+            .OfType<JsonObject>()
+            .Where(step => step["parallel"] is null)
+            .Select(step => JsonSerializer.Deserialize<JobStep>(step, options))
+            .Where(step => step is { Uses: not null } or { Run: not null })
+            .OfType<JobStep>()
+            .ToArray();
+    }
+
+    static JobStep[] ParseAllSteps(JsonNode stepsNode, JsonSerializerOptions options)
+    {
+        List<JobStep> allSteps = [];
+        CollectAllSteps(stepsNode, options, allSteps);
+        return allSteps.ToArray();
+    }
+
+    static void CollectAllSteps(JsonNode stepsNode, JsonSerializerOptions options, List<JobStep> allSteps)
+    {
+        if (stepsNode is not JsonArray stepsArray)
+        {
+            return;
+        }
+
+        foreach (var stepNode in stepsArray.OfType<JsonObject>())
+        {
+            if (stepNode["parallel"] is JsonNode parallelNode)
+            {
+                CollectAllSteps(parallelNode, options, allSteps);
+                continue;
+            }
+
+            var step = JsonSerializer.Deserialize<JobStep>(stepNode, options);
+            if (step is not null)
+            {
+                allSteps.Add(step);
+            }
+        }
+    }
 }
 
 public class WorkflowTrigger(string eventId)
@@ -142,6 +192,7 @@ public class WorkflowJob
     public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Defaults { get; set; } = new Dictionary<string, IReadOnlyDictionary<string, string>>();
     public JsonObject Strategy { get; set; }
     public JobStep[] Steps { get; set; } = [];
+    public JobStep[] AllSteps { get; set; } = [];
 }
 
 public class JobStep

--- a/src/RepoIntegrityTests/TestProjects.cs
+++ b/src/RepoIntegrityTests/TestProjects.cs
@@ -19,7 +19,7 @@ public partial class TestProjects
         var workflow = new ActionsWorkflow(ciPath);
 
         var explicitNetVersionsRequested = workflow.Jobs
-            .SelectMany(j => j.Steps.Where(s => s.Uses?.StartsWith("actions/setup-dotnet@") ?? false))
+            .SelectMany(j => j.AllSteps.Where(s => s.Uses?.StartsWith("actions/setup-dotnet@") ?? false))
             .Select(step =>
             {
                 var dotnetVersionsAtt = step.With.GetValueOrDefault("dotnet-version");

--- a/src/RepoIntegrityTests/WorkflowTests.cs
+++ b/src/RepoIntegrityTests/WorkflowTests.cs
@@ -34,7 +34,7 @@ public partial class WorkflowTests
                         continue;
                     }
 
-                    if (job.Steps.Any(step => step.Run is not null))
+                    if (job.AllSteps.Any(step => step.Run is not null))
                     {
                         f.Fail($"Job '{job.Id}' does not have a default shell defined at the workflow or job level.");
                     }


### PR DESCRIPTION
* Fixes [this type of code analysis failure](https://github.com/Particular/ServiceControl/actions/runs/31168889250/job/92835948003) when `setup-dotnet` action is placed inside a `parallel` block like how this commit https://github.com/Particular/ServiceControl/pull/5713/changes/3f744b9fb17ddc929c5095c433c95e8cae918d52#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f was attempting to do.

After the workflow YAML is changed to JSON, it deserializes into the .NET object shape, and at that time, the Jobs array is "weird" because the parallel node deserializes as an object with all null fields and the child steps are lost. This update post-processes the deserialized object by modifying the Steps array so that it only contains legitimate top-level steps, and then does another pass using the JsonNode to recursively find any nodes that look like steps and assigns that to a new AllSteps property.

This gives us a basic "is it in there" capability but does not go as far as trying to deserialize different types of nodes to truly understand parallel steps that have child steps, and also the different new "wait" types of steps. That would only be necessary if we discover we need to reason about semantics like ordering boundaries, wait/cancel relationships, or reporting exact nested paths, which we currently don't.